### PR TITLE
IOS: move work with CC/CXX passed by libretro-super

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ endif
    CXX =  cc++ $(fpic)
 else ifeq ($(platform),ios)
    fpic = -fPIC
-   CC = clang -arch armv7 -isysroot $(IOSSDK) -DHAVE_POSIX_MEMALIGN=1 -marm
-   CXX =  clang++ -arch armv7 -isysroot $(IOSSDK) -DHAVE_POSIX_MEMALIGN=1 -marm
+   CC = clang -arch armv7 -isysroot $(IOSSDK)
+   CXX =  clang++ -arch armv7 -isysroot $(IOSSDK)
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
 ifeq ($(OSX_LT_MAVERICKS),"YES")
@@ -80,6 +80,10 @@ ifeq ($(platform),osx)
       extraflags += $(ARCHFLAGS)
       link += $(ARCHFLAGS)
    endif
+endif
+
+ifeq ($(platform),ios)
+   extraflags += -DHAVE_POSIX_MEMALIGN=1 -marm
 endif
 
 # implicit rules


### PR DESCRIPTION
Move what should be CFLAGS for iOS out of the CC and CXX variables and into byuu's "extraflags".  Needed because libretro-super wants to tell cores what to use for CC and CXX instead of letting them figure it out.  Doesn't affect anything if you don't use libretro-super to build.

As of the time of this PR, libretro-super's libretro-build-ios.sh still doesn't work, but the version in my local tree builds 55 cores properly—56 with this patch.