### PR TITLE
Report git version with library_version

### DIFF
--- a/snes/Makefile
+++ b/snes/Makefile
@@ -30,6 +30,11 @@ else ifeq ($(profile),performance)
   snesppu := $(snes)/alt/ppu-performance
 endif
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	extraflags += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 obj/libretro.o: $(snes)/libretro/libretro.cpp $(snes)/libretro/* 
 
 obj/libco.o         : libco/libco.c libco/*

--- a/snes/libretro/libretro.cpp
+++ b/snes/libretro/libretro.cpp
@@ -300,7 +300,10 @@ void retro_cheat_set(unsigned index, bool enable, const char *code) {
 }
 
 void retro_get_system_info(struct retro_system_info *info) {
-  static string version("v085 (", SNES::Info::Profile, ")");
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+  static string version("v085 (", SNES::Info::Profile, ")", GIT_VERSION);
   info->library_name     = "bSNES";
   info->library_version  = version;
   info->valid_extensions = "sfc|smc";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.