### PR TITLE
Revert "Better error handling"

### DIFF
--- a/snes/libretro/libretro.cpp
+++ b/snes/libretro/libretro.cpp
@@ -469,9 +469,6 @@ static void init_descriptors(void)
 }
 
 bool retro_load_game(const struct retro_game_info *info) {
-   if (!info)
-      return false;
-
   retro_cheat_reset();
   init_descriptors();
 


### PR DESCRIPTION
This reverts commit ad401297f742f1ffdaacdac015c4b99218a0f30d.

This is not needed to prevent a segfault so might as well be removed. See https://github.com/libretro/RetroArch/issues/4493