### PR TITLE
Makefile: Use the standard 'rm -f' instead of the delete call for the clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,18 +115,12 @@ static: set-static static-library;
 include $(snes)/Makefile
 
 clean: 
-	-@$(call delete,obj/*.o)
-	-@$(call delete,obj/*.a)
-	-@$(call delete,obj/*.so)
-	-@$(call delete,obj/*.dylib)
-	-@$(call delete,obj/*.dll)
-	-@$(call delete,out/*.a)
-	-@$(call delete,out/*.so)
-	-@$(call delete,*.res)
-	-@$(call delete,*.pgd)
-	-@$(call delete,*.pgc)
-	-@$(call delete,*.ilk)
-	-@$(call delete,*.pdb)
-	-@$(call delete,*.manifest)
+	rm -f obj/*.o
+	rm -f obj/*.a
+	rm -f obj/*.so
+	rm -f obj/*.dylib
+	rm -f obj/*.dll
+	rm -f out/*.a
+	rm -f out/*.so
 
 help:;

--- a/nall/Makefile
+++ b/nall/Makefile
@@ -32,12 +32,6 @@ ifeq ($(platform),)
   endif
 endif
 
-ifeq ($(platform),win)
-  delete = del /F /Q $(subst /,\,$1)
-else
-  delete = rm -f $1
-endif
-
 ifeq ($(prefix),)
   prefix := /usr/local
 endif

--- a/snes/.gitignore
+++ b/snes/.gitignore
@@ -1,6 +1,5 @@
 *.so
 *.o
 *.dll
-*.manifest
 *.a
 *.dylib


### PR DESCRIPTION
This is weird, unnecessarily hard to understand and completely unnecessary. Additionally cleaning it up will allow the buildbot script to use the standard `make clean` command in the future.